### PR TITLE
Fix NRT errors and enable TreatWarningsAsErrors

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,6 +16,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageOutputPath>$(SolutionDir)artifacts</PackageOutputPath>
     <PackageIcon>foundatio-icon.png</PackageIcon>
@@ -37,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/build/common.props
+++ b/build/common.props
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.200" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="2.1.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/samples/Foundatio.AzureStorage.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Dequeue/Program.cs
@@ -48,9 +48,21 @@ rootCommand.SetAction(async parseResult =>
                           Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING") ??
                           EmulatorConnectionString;
 
-    var queueName = parseResult.GetValue(queueOption) ?? "sample-queue";
+    var queueName = parseResult.GetValue(queueOption);
     var mode = parseResult.GetValue(modeOption);
     var count = parseResult.GetValue(countOption);
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        Console.Error.WriteLine("Error: Connection string is required. Use --connection-string or set AZURE_STORAGE_CONNECTION_STRING.");
+        return 1;
+    }
+
+    if (string.IsNullOrWhiteSpace(queueName))
+    {
+        Console.Error.WriteLine("Error: Queue name is required. Use --queue.");
+        return 1;
+    }
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Storage Emulator" : "Custom connection string")}");
     Console.WriteLine($"Mode: {mode}");

--- a/samples/Foundatio.AzureStorage.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Dequeue/Program.cs
@@ -60,7 +60,7 @@ rootCommand.SetAction(async parseResult =>
     Console.WriteLine("Press Ctrl+C to stop...");
     Console.WriteLine();
 
-    await DequeueMessages(connectionString, queueName, mode, count);
+    await DequeueMessages(connectionString, queueName!, mode, count);
     return 0;
 });
 

--- a/samples/Foundatio.AzureStorage.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Dequeue/Program.cs
@@ -127,7 +127,7 @@ static async Task DequeueMessages(string connectionString, string queueName, Azu
                 if (entry.Properties != null && entry.Properties.Count > 0)
                 {
                     logger.LogInformation("  Properties: [{Properties}]",
-                        string.Join(", ", entry.Properties.Select(p => $"{p.Key}={p.Value}")));
+                        String.Join(", ", entry.Properties.Select(p => $"{p.Key}={p.Value}")));
                 }
                 else
                 {

--- a/samples/Foundatio.AzureStorage.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Dequeue/Program.cs
@@ -48,7 +48,7 @@ rootCommand.SetAction(async parseResult =>
                           Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING") ??
                           EmulatorConnectionString;
 
-    var queueName = parseResult.GetValue(queueOption);
+    var queueName = parseResult.GetValue(queueOption) ?? "sample-queue";
     var mode = parseResult.GetValue(modeOption);
     var count = parseResult.GetValue(countOption);
 
@@ -60,7 +60,7 @@ rootCommand.SetAction(async parseResult =>
     Console.WriteLine("Press Ctrl+C to stop...");
     Console.WriteLine();
 
-    await DequeueMessages(connectionString, queueName!, mode, count);
+    await DequeueMessages(connectionString, queueName, mode, count);
     return 0;
 });
 

--- a/samples/Foundatio.AzureStorage.Dequeue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Dequeue/Program.cs
@@ -120,7 +120,7 @@ static async Task DequeueMessages(string connectionString, string queueName, Azu
                 processed++;
 
                 logger.LogInformation("Dequeued message {MessageId}: '{Message}' from '{Source}' at {Timestamp}",
-                    entry.Id, entry.Value.Message, entry.Value.Source, entry.Value.Timestamp);
+                    entry.Id, entry.Value?.Message, entry.Value?.Source, entry.Value?.Timestamp);
 
                 logger.LogInformation("  CorrelationId: '{CorrelationId}'", entry.CorrelationId ?? "<none>");
 

--- a/samples/Foundatio.AzureStorage.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/Program.cs
@@ -132,7 +132,7 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
 
         logger.LogInformation("Enqueued message {MessageId}: '{Message}' with CorrelationId: '{CorrelationId}' Properties: [{Properties}]",
             messageId, sampleMessage.Message, correlationId ?? "<none>",
-            string.Join(", ", queueProperties.Select(p => $"{p.Key}={p.Value}")));
+            String.Join(", ", queueProperties.Select(p => $"{p.Key}={p.Value}")));
     }
 
     logger.LogInformation("Successfully enqueued {Count} message(s)", count);

--- a/samples/Foundatio.AzureStorage.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/Program.cs
@@ -68,12 +68,30 @@ rootCommand.SetAction(async parseResult =>
                           Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING") ??
                           EmulatorConnectionString;
 
-    var queueName = parseResult.GetValue(queueOption) ?? "sample-queue";
-    var message = parseResult.GetValue(messageOption) ?? "Hello World";
+    var queueName = parseResult.GetValue(queueOption);
+    var message = parseResult.GetValue(messageOption);
     var correlationId = parseResult.GetValue(correlationIdOption);
-    var properties = parseResult.GetValue(propertiesOption) ?? Array.Empty<string>();
+    var properties = parseResult.GetValue(propertiesOption) ?? [];
     var mode = parseResult.GetValue(modeOption);
     var count = parseResult.GetValue(countOption);
+
+    if (string.IsNullOrWhiteSpace(connectionString))
+    {
+        Console.Error.WriteLine("Error: Connection string is required. Use --connection-string or set AZURE_STORAGE_CONNECTION_STRING.");
+        return 1;
+    }
+
+    if (string.IsNullOrWhiteSpace(queueName))
+    {
+        Console.Error.WriteLine("Error: Queue name is required. Use --queue.");
+        return 1;
+    }
+
+    if (string.IsNullOrWhiteSpace(message))
+    {
+        Console.Error.WriteLine("Error: Message is required. Use --message.");
+        return 1;
+    }
 
     Console.WriteLine($"Using connection: {(connectionString == EmulatorConnectionString ? "Azure Storage Emulator" : "Custom connection string")}");
     Console.WriteLine($"Mode: {mode}");
@@ -100,15 +118,12 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
         .LoggerFactory(loggerFactory));
 
     var queueProperties = new Dictionary<string, string>();
-    if (properties != null)
+    foreach (var prop in properties)
     {
-        foreach (var prop in properties)
+        var parts = prop.Split('=', 2);
+        if (parts.Length == 2)
         {
-            var parts = prop.Split('=', 2);
-            if (parts.Length == 2)
-            {
-                queueProperties[parts[0]] = parts[1];
-            }
+            queueProperties[parts[0]] = parts[1];
         }
     }
 

--- a/samples/Foundatio.AzureStorage.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/Program.cs
@@ -68,10 +68,10 @@ rootCommand.SetAction(async parseResult =>
                           Environment.GetEnvironmentVariable("AZURE_STORAGE_CONNECTION_STRING") ??
                           EmulatorConnectionString;
 
-    var queueName = parseResult.GetValue(queueOption);
-    var message = parseResult.GetValue(messageOption);
+    var queueName = parseResult.GetValue(queueOption) ?? "sample-queue";
+    var message = parseResult.GetValue(messageOption) ?? "Hello World";
     var correlationId = parseResult.GetValue(correlationIdOption);
-    var properties = parseResult.GetValue(propertiesOption);
+    var properties = parseResult.GetValue(propertiesOption) ?? Array.Empty<string>();
     var mode = parseResult.GetValue(modeOption);
     var count = parseResult.GetValue(countOption);
 
@@ -79,7 +79,7 @@ rootCommand.SetAction(async parseResult =>
     Console.WriteLine($"Mode: {mode}");
     Console.WriteLine();
 
-    await EnqueueMessages(connectionString, queueName!, message!, correlationId, properties!, mode, count);
+    await EnqueueMessages(connectionString, queueName, message, correlationId, properties, mode, count);
     return 0;
 });
 

--- a/samples/Foundatio.AzureStorage.Enqueue/Program.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/Program.cs
@@ -79,14 +79,14 @@ rootCommand.SetAction(async parseResult =>
     Console.WriteLine($"Mode: {mode}");
     Console.WriteLine();
 
-    await EnqueueMessages(connectionString, queueName, message, correlationId, properties, mode, count);
+    await EnqueueMessages(connectionString, queueName!, message!, correlationId, properties!, mode, count);
     return 0;
 });
 
 // Parse and invoke
 return await rootCommand.Parse(args).InvokeAsync();
 
-static async Task EnqueueMessages(string connectionString, string queueName, string message, string correlationId, string[] properties, AzureStorageQueueCompatibilityMode mode, int count)
+static async Task EnqueueMessages(string connectionString, string queueName, string message, string? correlationId, string[] properties, AzureStorageQueueCompatibilityMode mode, int count)
 {
     using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Information));
     var logger = loggerFactory.CreateLogger("Enqueue");
@@ -122,9 +122,11 @@ static async Task EnqueueMessages(string connectionString, string queueName, str
 
         var entryOptions = new QueueEntryOptions
         {
-            CorrelationId = correlationId,
-            Properties = queueProperties.Count > 0 ? queueProperties : null
+            CorrelationId = correlationId
         };
+
+        if (queueProperties.Count > 0)
+            entryOptions.Properties = queueProperties;
 
         var messageId = await queue.EnqueueAsync(sampleMessage, entryOptions);
 

--- a/samples/Foundatio.AzureStorage.Enqueue/SampleMessage.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/SampleMessage.cs
@@ -4,7 +4,7 @@ namespace Foundatio.AzureStorage.Samples;
 
 public record SampleMessage
 {
-    public string Message { get; init; } = String.Empty;
+    public required string Message { get; init; }
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public string Source { get; init; } = String.Empty;
+    public required string Source { get; init; }
 }

--- a/samples/Foundatio.AzureStorage.Enqueue/SampleMessage.cs
+++ b/samples/Foundatio.AzureStorage.Enqueue/SampleMessage.cs
@@ -4,7 +4,7 @@ namespace Foundatio.AzureStorage.Samples;
 
 public record SampleMessage
 {
-    public string Message { get; init; } = string.Empty;
+    public string Message { get; init; } = String.Empty;
     public DateTime Timestamp { get; init; } = DateTime.UtcNow;
-    public string Source { get; init; } = string.Empty;
+    public string Source { get; init; } = String.Empty;
 }

--- a/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
+++ b/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
+++ b/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
+++ b/src/Foundatio.AzureStorage/Foundatio.AzureStorage.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.25.0" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -27,7 +27,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
 
     public AzureStorageQueue(AzureStorageQueueOptions<T> options) : base(options)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
+        ArgumentException.ThrowIfNullOrWhiteSpace(options?.ConnectionString, nameof(options.ConnectionString));
 
         var clientOptions = new QueueClientOptions();
 #pragma warning disable CS0618 // Legacy mode is still supported internally for backward compatibility
@@ -224,7 +224,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
         {
             _logger.LogWarning(deserializeException, "Error deserializing message {MessageId} (attempt {DequeueCount}), abandoning for retry", message.MessageId, message.DequeueCount);
 
-            var poisonEntry = new AzureStorageQueueEntry<T>(message, null, null, default!, this);
+            var poisonEntry = new AzureStorageQueueEntry<T>(message, null, null, null, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -515,5 +515,5 @@ internal record QueueMessageEnvelope<T> where T : class
     /// <summary>
     /// The actual message payload
     /// </summary>
-    public T Data { get; init; } = null!;
+    public required T Data { get; init; }
 }

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -27,7 +27,8 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
 
     public AzureStorageQueue(AzureStorageQueueOptions<T> options) : base(options)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(options?.ConnectionString, nameof(options.ConnectionString));
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
 
         var clientOptions = new QueueClientOptions();
 #pragma warning disable CS0618 // Legacy mode is still supported internally for backward compatibility

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -179,6 +179,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
         T? data;
         string? correlationId = null;
         IDictionary<string, string>? properties = null;
+        Exception? deserializeException = null;
 
         try
         {
@@ -186,6 +187,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
             {
                 try
                 {
+                    // Unwrap envelope to extract metadata
                     var envelope = _serializer.Deserialize<QueueMessageEnvelope<T>>(message.Body.ToArray());
                     if (envelope is not null)
                     {
@@ -200,23 +202,28 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
                 }
                 catch (Exception ex)
                 {
+                    // Fallback: try legacy format (raw T) for messages written before the envelope format.
+                    // If this also fails, let the exception propagate to the outer catch which will dead-letter it.
                     _logger.LogWarning(ex, "Failed to deserialize message {MessageId} as envelope format, attempting legacy format fallback", message.MessageId);
                     data = _serializer.Deserialize<T>(message.Body.ToArray());
                 }
             }
             else
             {
+                // Legacy mode: deserialize data directly (no envelope)
                 data = _serializer.Deserialize<T>(message.Body.ToArray());
             }
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Error deserializing message {MessageId} (attempt {DequeueCount}), abandoning for retry", message.MessageId, message.DequeueCount);
             data = null;
+            deserializeException = ex;
         }
 
         if (data is null)
         {
+            _logger.LogWarning(deserializeException, "Error deserializing message {MessageId} (attempt {DequeueCount}), abandoning for retry", message.MessageId, message.DequeueCount);
+
             var poisonEntry = new AzureStorageQueueEntry<T>(message, null, null, default!, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -71,7 +71,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
         }
     }
 
-    protected override async Task<string> EnqueueImplAsync(T data, QueueEntryOptions options)
+    protected override async Task<string?> EnqueueImplAsync(T data, QueueEntryOptions options)
     {
         if (!await OnEnqueuingAsync(data, options).AnyContext())
             return null;
@@ -110,7 +110,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
         return response.Value.MessageId;
     }
 
-    protected override async Task<IQueueEntry<T>> DequeueImplAsync(CancellationToken linkedCancellationToken)
+    protected override async Task<IQueueEntry<T>?> DequeueImplAsync(CancellationToken linkedCancellationToken)
     {
         _logger.LogTrace("Checking for message: IsCancellationRequested={IsCancellationRequested} VisibilityTimeout={VisibilityTimeout}", linkedCancellationToken.IsCancellationRequested, _options.WorkItemTimeout);
 
@@ -177,9 +177,9 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
             message.MessageId, insertedOn, nowUtc, queueTime.TotalMilliseconds, linkedCancellationToken.IsCancellationRequested);
         Interlocked.Increment(ref _dequeuedCount);
 
-        T data;
-        string correlationId = null;
-        IDictionary<string, string> properties = null;
+        T? data;
+        string? correlationId = null;
+        IDictionary<string, string>? properties = null;
 
         try
         {
@@ -187,31 +187,38 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
             {
                 try
                 {
-                    // Unwrap envelope to extract metadata
                     var envelope = _serializer.Deserialize<QueueMessageEnvelope<T>>(message.Body.ToArray());
-                    data = envelope.Data;
-                    correlationId = envelope.CorrelationId;
-                    properties = envelope.Properties;
+                    if (envelope is not null)
+                    {
+                        data = envelope.Data;
+                        correlationId = envelope.CorrelationId;
+                        properties = envelope.Properties;
+                    }
+                    else
+                    {
+                        data = _serializer.Deserialize<T>(message.Body.ToArray());
+                    }
                 }
                 catch (Exception ex)
                 {
-                    // Fallback: try legacy format (raw T) for messages written before the envelope format.
-                    // If this also fails, let the exception propagate to the outer catch which will dead-letter it.
                     _logger.LogWarning(ex, "Failed to deserialize message {MessageId} as envelope format, attempting legacy format fallback", message.MessageId);
                     data = _serializer.Deserialize<T>(message.Body.ToArray());
                 }
             }
             else
             {
-                // Legacy mode: deserialize data directly (no envelope)
                 data = _serializer.Deserialize<T>(message.Body.ToArray());
             }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error deserializing message {MessageId} (attempt {DequeueCount}), abandoning for retry", message.MessageId, message.DequeueCount);
+            data = null;
+        }
 
-            var poisonEntry = new AzureStorageQueueEntry<T>(message, null, null, null, this);
+        if (data is null)
+        {
+            var poisonEntry = new AzureStorageQueueEntry<T>(message, null, null, default!, this);
             await AbandonAsync(poisonEntry).AnyContext();
             return null;
         }
@@ -419,7 +426,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
             {
                 _logger.LogTrace("WorkerLoop Signaled {QueueName}", _options.Name);
 
-                IQueueEntry<T> queueEntry = null;
+                IQueueEntry<T>? queueEntry = null;
                 try
                 {
                     queueEntry = await DequeueImplAsync(linkedCancellationToken.Token).AnyContext();
@@ -498,15 +505,15 @@ internal record QueueMessageEnvelope<T> where T : class
     /// <summary>
     /// Correlation ID for distributed tracing
     /// </summary>
-    public string CorrelationId { get; init; }
+    public string? CorrelationId { get; init; }
 
     /// <summary>
     /// Custom properties/metadata
     /// </summary>
-    public IDictionary<string, string> Properties { get; init; }
+    public IDictionary<string, string>? Properties { get; init; }
 
     /// <summary>
     /// The actual message payload
     /// </summary>
-    public T Data { get; init; }
+    public T Data { get; init; } = null!;
 }

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueue.cs
@@ -27,8 +27,7 @@ public class AzureStorageQueue<T> : QueueBase<T, AzureStorageQueueOptions<T>> wh
 
     public AzureStorageQueue(AzureStorageQueueOptions<T> options) : base(options)
     {
-        if (String.IsNullOrEmpty(options.ConnectionString))
-            throw new ArgumentException("ConnectionString is required.");
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
 
         var clientOptions = new QueueClientOptions();
 #pragma warning disable CS0618 // Legacy mode is still supported internally for backward compatibility

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueueEntry.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueueEntry.cs
@@ -14,7 +14,7 @@ public class AzureStorageQueueEntry<T> : QueueEntry<T> where T : class
     /// </summary>
     public string PopReceipt { get; internal set; }
 
-    public AzureStorageQueueEntry(QueueMessage message, string correlationId, IDictionary<string, string> properties, T data, IQueue<T> queue)
+    public AzureStorageQueueEntry(QueueMessage message, string? correlationId, IDictionary<string, string>? properties, T data, IQueue<T> queue)
         : base(message.MessageId, correlationId, data, queue, message.InsertedOn?.UtcDateTime ?? DateTime.MinValue, (int)message.DequeueCount)
     {
         UnderlyingMessage = message;

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueueEntry.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueueEntry.cs
@@ -14,7 +14,7 @@ public class AzureStorageQueueEntry<T> : QueueEntry<T> where T : class
     /// </summary>
     public string PopReceipt { get; internal set; }
 
-    public AzureStorageQueueEntry(QueueMessage message, string? correlationId, IDictionary<string, string>? properties, T data, IQueue<T> queue)
+    public AzureStorageQueueEntry(QueueMessage message, string? correlationId, IDictionary<string, string>? properties, T? data, IQueue<T> queue)
         : base(message.MessageId, correlationId, data, queue, message.InsertedOn?.UtcDateTime ?? DateTime.MinValue, (int)message.DequeueCount)
     {
         UnderlyingMessage = message;

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
@@ -25,7 +25,7 @@ public enum AzureStorageQueueCompatibilityMode
 
 public class AzureStorageQueueOptions<T> : SharedQueueOptions<T> where T : class
 {
-    public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; } = null!;
 
     /// <summary>
     /// The interval to wait between polling for new messages when the queue is empty.
@@ -71,7 +71,7 @@ public class AzureStorageQueueOptions<T> : SharedQueueOptions<T> where T : class
     /// };
     /// </code>
     /// </example>
-    public Action<RetryOptions> ConfigureRetry { get; set; }
+    public Action<RetryOptions>? ConfigureRetry { get; set; }
 }
 
 public class AzureStorageQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T, AzureStorageQueueOptions<T>, AzureStorageQueueOptionsBuilder<T>> where T : class

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
@@ -25,7 +25,7 @@ public enum AzureStorageQueueCompatibilityMode
 
 public class AzureStorageQueueOptions<T> : SharedQueueOptions<T> where T : class
 {
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// The interval to wait between polling for new messages when the queue is empty.

--- a/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
+++ b/src/Foundatio.AzureStorage/Queues/AzureStorageQueueOptions.cs
@@ -78,7 +78,7 @@ public class AzureStorageQueueOptionsBuilder<T> : SharedQueueOptionsBuilder<T, A
 {
     public AzureStorageQueueOptionsBuilder<T> ConnectionString(string connectionString)
     {
-        ArgumentException.ThrowIfNullOrEmpty(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
         Target.ConnectionString = connectionString;
         return this;

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -96,7 +96,10 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path)!;
+        string? normalizedPath = NormalizePath(path);
+        if (normalizedPath is null)
+            return null;
+
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -66,7 +66,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);
@@ -96,7 +96,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
 
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
@@ -127,7 +127,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);
@@ -140,7 +140,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(stream);
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         try
@@ -166,8 +166,8 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentException.ThrowIfNullOrEmpty(newPath);
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedNewPath = NormalizePath(newPath)!;
+        string normalizedPath = NormalizePath(path);
+        string normalizedNewPath = NormalizePath(newPath);
         _logger.LogDebug("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         try
@@ -201,8 +201,8 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentException.ThrowIfNullOrEmpty(targetPath);
 
-        string normalizedPath = NormalizePath(path)!;
-        string normalizedTargetPath = NormalizePath(targetPath)!;
+        string normalizedPath = NormalizePath(path);
+        string normalizedTargetPath = NormalizePath(targetPath);
         _logger.LogDebug("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -239,7 +239,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path)!;
+        string normalizedPath = NormalizePath(path);
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         try
@@ -368,9 +368,9 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         };
     }
 
-    private static string? NormalizePath(string? path)
+    private static string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private record SearchCriteria
@@ -384,7 +384,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern)!;
+        string normalizedSearchPattern = NormalizePath(searchPattern);
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -373,7 +373,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
 
     private record SearchCriteria
     {
-        public string Prefix { get; set; } = null!;
+        public string Prefix { get; set; } = String.Empty;
         public Regex? Pattern { get; set; }
     }
 

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -96,9 +96,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string? normalizedPath = NormalizePath(path);
-        if (normalizedPath is null)
-            return null;
+        string normalizedPath = NormalizePath(path)!;
 
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -66,7 +66,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Getting file stream for {Path}", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);
@@ -96,7 +96,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);
@@ -126,7 +126,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Checking if {Path} exists", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);
@@ -139,7 +139,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentNullException.ThrowIfNull(stream);
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Saving {Path}", normalizedPath);
 
         try
@@ -165,8 +165,8 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentException.ThrowIfNullOrEmpty(newPath);
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedNewPath = NormalizePath(newPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedNewPath = NormalizePath(newPath)!;
         _logger.LogDebug("Renaming {Path} to {NewPath}", normalizedPath, normalizedNewPath);
 
         try
@@ -200,8 +200,8 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
         ArgumentException.ThrowIfNullOrEmpty(targetPath);
 
-        string normalizedPath = NormalizePath(path);
-        string normalizedTargetPath = NormalizePath(targetPath);
+        string normalizedPath = NormalizePath(path)!;
+        string normalizedTargetPath = NormalizePath(targetPath)!;
         _logger.LogDebug("Copying {Path} to {TargetPath}", normalizedPath, normalizedTargetPath);
 
         try
@@ -238,7 +238,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
-        string normalizedPath = NormalizePath(path);
+        string normalizedPath = NormalizePath(path)!;
         _logger.LogTrace("Deleting {Path}", normalizedPath);
 
         try
@@ -367,14 +367,14 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         };
     }
 
-    private static string NormalizePath(string path)
+    private static string? NormalizePath(string? path)
     {
-        return path.Replace('\\', '/');
+        return path?.Replace('\\', '/');
     }
 
     private record SearchCriteria
     {
-        public string Prefix { get; set; } = String.Empty;
+        public required string Prefix { get; set; }
         public Regex? Pattern { get; set; }
     }
 
@@ -383,7 +383,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
 
-        string normalizedSearchPattern = NormalizePath(searchPattern);
+        string normalizedSearchPattern = NormalizePath(searchPattern)!;
         int wildcardPos = normalizedSearchPattern.IndexOf('*');
         bool hasWildcard = wildcardPos >= 0;
 

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -97,7 +97,6 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         ArgumentException.ThrowIfNullOrEmpty(path);
 
         string normalizedPath = NormalizePath(path);
-
         _logger.LogTrace("Getting file info for {Path}", normalizedPath);
 
         var blobClient = _container.GetBlobClient(normalizedPath);

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -58,10 +58,10 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     public BlobContainerClient Container => _container;
 
     [Obsolete($"Use {nameof(GetFileStreamAsync)} with {nameof(StreamMode)} instead to define read or write behavior of stream")]
-    public Task<Stream> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
+    public Task<Stream?> GetFileStreamAsync(string path, CancellationToken cancellationToken = default)
         => GetFileStreamAsync(path, StreamMode.Read, cancellationToken);
 
-    public async Task<Stream> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
+    public async Task<Stream?> GetFileStreamAsync(string path, StreamMode streamMode, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
@@ -91,7 +91,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         }
     }
 
-    public async Task<FileSpec> GetFileInfoAsync(string path)
+    public async Task<FileSpec?> GetFileInfoAsync(string path)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
@@ -255,7 +255,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         }
     }
 
-    public async Task<int> DeleteFilesAsync(string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<int> DeleteFilesAsync(string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         var files = await GetFileListAsync(searchPattern, cancellationToken: cancellationToken).AnyContext();
         int count = 0;
@@ -273,7 +273,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         return count;
     }
 
-    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string searchPattern = null, CancellationToken cancellationToken = default)
+    public async Task<PagedFileListResult> GetPagedFileListAsync(int pageSize = 100, string? searchPattern = null, CancellationToken cancellationToken = default)
     {
         if (pageSize <= 0)
             return PagedFileListResult.Empty;
@@ -283,7 +283,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         return result;
     }
 
-    private async Task<NextPageResult> GetFiles(string searchPattern, int page, int pageSize, CancellationToken cancellationToken)
+    private async Task<NextPageResult> GetFiles(string? searchPattern, int page, int pageSize, CancellationToken cancellationToken)
     {
         int pagingLimit = pageSize;
         int skip = (page - 1) * pagingLimit;
@@ -307,7 +307,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         };
     }
 
-    private async Task<List<FileSpec>> GetFileListAsync(string searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
+    private async Task<List<FileSpec>> GetFileListAsync(string? searchPattern = null, int? limit = null, int? skip = null, CancellationToken cancellationToken = default)
     {
         if (limit is <= 0)
             return new List<FileSpec>();
@@ -368,16 +368,16 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
 
     private static string NormalizePath(string path)
     {
-        return path?.Replace('\\', '/');
+        return path.Replace('\\', '/');
     }
 
     private record SearchCriteria
     {
-        public string Prefix { get; set; }
-        public Regex Pattern { get; set; }
+        public string Prefix { get; set; } = null!;
+        public Regex? Pattern { get; set; }
     }
 
-    private SearchCriteria GetRequestCriteria(string searchPattern)
+    private SearchCriteria GetRequestCriteria(string? searchPattern)
     {
         if (String.IsNullOrEmpty(searchPattern))
             return new SearchCriteria { Prefix = String.Empty };
@@ -387,7 +387,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
         bool hasWildcard = wildcardPos >= 0;
 
         string prefix = normalizedSearchPattern;
-        Regex patternRegex = null;
+        Regex? patternRegex = null;
 
         if (hasWildcard)
         {

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorage.cs
@@ -27,6 +27,7 @@ public class AzureFileStorage : IFileStorage, IHaveLogger, IHaveLoggerFactory, I
     public AzureFileStorage(AzureFileStorageOptions options)
     {
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentException.ThrowIfNullOrWhiteSpace(options.ConnectionString, nameof(options.ConnectionString));
 
         _timeProvider = options.TimeProvider ?? TimeProvider.System;
         _serializer = options.Serializer ?? DefaultSerializer.Instance;

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Storage;
 
 public class AzureFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; } = null!;
+    public string? ConnectionString { get; set; }
     public string ContainerName { get; set; } = "storage";
 
     /// <summary>

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
@@ -29,7 +29,7 @@ public class AzureFileStorageOptionsBuilder : SharedOptionsBuilder<AzureFileStor
 {
     public AzureFileStorageOptionsBuilder ConnectionString(string connectionString)
     {
-        ArgumentException.ThrowIfNullOrEmpty(connectionString);
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
         Target.ConnectionString = connectionString;
         return this;

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
@@ -5,7 +5,7 @@ namespace Foundatio.Storage;
 
 public class AzureFileStorageOptions : SharedOptions
 {
-    public string ConnectionString { get; set; }
+    public string ConnectionString { get; set; } = null!;
     public string ContainerName { get; set; } = "storage";
 
     /// <summary>
@@ -22,7 +22,7 @@ public class AzureFileStorageOptions : SharedOptions
     /// };
     /// </code>
     /// </example>
-    public Action<RetryOptions> ConfigureRetry { get; set; }
+    public Action<RetryOptions>? ConfigureRetry { get; set; }
 }
 
 public class AzureFileStorageOptionsBuilder : SharedOptionsBuilder<AzureFileStorageOptions, AzureFileStorageOptionsBuilder>

--- a/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
+++ b/src/Foundatio.AzureStorage/Storage/AzureFileStorageOptions.cs
@@ -37,7 +37,7 @@ public class AzureFileStorageOptionsBuilder : SharedOptionsBuilder<AzureFileStor
 
     public AzureFileStorageOptionsBuilder ContainerName(string containerName)
     {
-        ArgumentException.ThrowIfNullOrEmpty(containerName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
 
         Target.ContainerName = containerName;
         return this;

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.32" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.35" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.36" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta3.41" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
@@ -271,7 +271,6 @@ public class AzureStorageQueueTests : QueueTestBase
         var entry = await defaultQueue.DequeueAsync(dequeueCts.Token);
 
         // Assert
-        Assert.NotNull(entry);
         Assert.NotNull(entry?.Value);
         Assert.Equal("legacy-item", entry.Value.Data);
         Assert.Equal(42, entry.Value.Id);

--- a/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
@@ -272,7 +272,7 @@ public class AzureStorageQueueTests : QueueTestBase
 
         // Assert
         Assert.NotNull(entry);
-        Assert.NotNull(entry.Value);
+        Assert.NotNull(entry?.Value);
         Assert.Equal("legacy-item", entry.Value.Data);
         Assert.Equal(42, entry.Value.Id);
         Assert.Null(entry.CorrelationId);

--- a/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
@@ -20,11 +20,11 @@ public class AzureStorageQueueTests : QueueTestBase
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
+    protected override IQueue<SimpleWorkItem>? GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
         string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null!;
+            return null;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
         return new AzureStorageQueue<SimpleWorkItem>(o =>

--- a/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
@@ -27,24 +27,16 @@ public class AzureStorageQueueTests : QueueTestBase
             return null;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
-        return new AzureStorageQueue<SimpleWorkItem>(o =>
-        {
-            var builder = o
-                .ConnectionString(connectionString)
-                .Name(_queueName)
-                .Retries(retries)
-                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-                .DequeueInterval(TimeSpan.FromSeconds(1))
-                .MetricsPollingInterval(TimeSpan.Zero)
-                .LoggerFactory(Log);
-
-            if (timeProvider is not null)
-                builder.TimeProvider(timeProvider);
-            if (serializer is not null)
-                builder.Serializer(serializer);
-
-            return builder;
-        });
+        return new AzureStorageQueue<SimpleWorkItem>(o => o
+            .ConnectionString(connectionString)
+            .Name(_queueName)
+            .Retries(retries)
+            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+            .DequeueInterval(TimeSpan.FromSeconds(1))
+            .MetricsPollingInterval(TimeSpan.Zero)
+            .TimeProvider(timeProvider)
+            .Serializer(serializer)
+            .LoggerFactory(Log));
     }
 
     protected override Task CleanupQueueAsync(IQueue<SimpleWorkItem> queue)
@@ -244,7 +236,7 @@ public class AzureStorageQueueTests : QueueTestBase
     public async Task DequeueAsync_WithLegacyFormatMessage_DeserializesWithFallbackAsync()
     {
         // Arrange - Inject a raw (non-envelope) message simulating legacy format
-        var connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return;
 
@@ -305,7 +297,7 @@ public class AzureStorageQueueTests : QueueTestBase
     [Fact]
     public async Task DequeueAsync_WithCorruptMessage_MovesToDeadletterAsync()
     {
-        var connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return;
 

--- a/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/AzureStorageQueueTests.cs
@@ -20,23 +20,31 @@ public class AzureStorageQueueTests : QueueTestBase
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[] retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider timeProvider = null, ISerializer serializer = null)
+    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
-        string connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null;
+            return null!;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
-        return new AzureStorageQueue<SimpleWorkItem>(o => o
-            .ConnectionString(connectionString)
-            .Name(_queueName)
-            .Retries(retries)
-            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-            .DequeueInterval(TimeSpan.FromSeconds(1))
-            .MetricsPollingInterval(TimeSpan.Zero)
-            .TimeProvider(timeProvider)
-            .Serializer(serializer)
-            .LoggerFactory(Log));
+        return new AzureStorageQueue<SimpleWorkItem>(o =>
+        {
+            var builder = o
+                .ConnectionString(connectionString)
+                .Name(_queueName)
+                .Retries(retries)
+                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+                .DequeueInterval(TimeSpan.FromSeconds(1))
+                .MetricsPollingInterval(TimeSpan.Zero)
+                .LoggerFactory(Log);
+
+            if (timeProvider is not null)
+                builder.TimeProvider(timeProvider);
+            if (serializer is not null)
+                builder.Serializer(serializer);
+
+            return builder;
+        });
     }
 
     protected override Task CleanupQueueAsync(IQueue<SimpleWorkItem> queue)
@@ -236,7 +244,7 @@ public class AzureStorageQueueTests : QueueTestBase
     public async Task DequeueAsync_WithLegacyFormatMessage_DeserializesWithFallbackAsync()
     {
         // Arrange - Inject a raw (non-envelope) message simulating legacy format
-        string connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        var connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return;
 
@@ -256,6 +264,7 @@ public class AzureStorageQueueTests : QueueTestBase
         await defaultQueue.EnqueueAsync(new SimpleWorkItem { Data = "setup" });
         using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var setupEntry = await defaultQueue.DequeueAsync(setupCts.Token);
+        Assert.NotNull(setupEntry);
         await setupEntry.CompleteAsync();
 
         // Inject a raw JSON message (no envelope wrapper) using QueueClient directly
@@ -271,6 +280,7 @@ public class AzureStorageQueueTests : QueueTestBase
 
         // Assert
         Assert.NotNull(entry);
+        Assert.NotNull(entry.Value);
         Assert.Equal("legacy-item", entry.Value.Data);
         Assert.Equal(42, entry.Value.Id);
         Assert.Null(entry.CorrelationId);
@@ -295,7 +305,7 @@ public class AzureStorageQueueTests : QueueTestBase
     [Fact]
     public async Task DequeueAsync_WithCorruptMessage_MovesToDeadletterAsync()
     {
-        string connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        var connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
             return;
 
@@ -315,6 +325,7 @@ public class AzureStorageQueueTests : QueueTestBase
         await queue.EnqueueAsync(new SimpleWorkItem { Data = "setup" });
         using var setupCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var setupEntry = await queue.DequeueAsync(setupCts.Token);
+        Assert.NotNull(setupEntry);
         await setupEntry.CompleteAsync();
 
         // Inject a completely invalid message (not valid JSON at all)

--- a/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
@@ -24,27 +24,19 @@ public class LegacyAzureStorageQueueTests : QueueTestBase
             return null;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
-        return new AzureStorageQueue<SimpleWorkItem>(o =>
-        {
-            var builder = o
-                .ConnectionString(connectionString)
-                .Name(_queueName)
+        return new AzureStorageQueue<SimpleWorkItem>(o => o
+            .ConnectionString(connectionString)
+            .Name(_queueName)
 #pragma warning disable CS0618 // Testing legacy mode intentionally
-                .CompatibilityMode(AzureStorageQueueCompatibilityMode.Legacy)
+            .CompatibilityMode(AzureStorageQueueCompatibilityMode.Legacy)
 #pragma warning restore CS0618
-                .Retries(retries)
-                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-                .DequeueInterval(TimeSpan.FromSeconds(1))
-                .MetricsPollingInterval(TimeSpan.Zero)
-                .LoggerFactory(Log);
-
-            if (timeProvider is not null)
-                builder.TimeProvider(timeProvider);
-            if (serializer is not null)
-                builder.Serializer(serializer);
-
-            return builder;
-        });
+            .Retries(retries)
+            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+            .DequeueInterval(TimeSpan.FromSeconds(1))
+            .MetricsPollingInterval(TimeSpan.Zero)
+            .TimeProvider(timeProvider)
+            .Serializer(serializer)
+            .LoggerFactory(Log));
     }
 
     protected override Task CleanupQueueAsync(IQueue<SimpleWorkItem> queue)

--- a/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
@@ -17,26 +17,34 @@ public class LegacyAzureStorageQueueTests : QueueTestBase
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[] retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider timeProvider = null, ISerializer serializer = null)
+    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
-        string connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null;
+            return null!;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
-        return new AzureStorageQueue<SimpleWorkItem>(o => o
-            .ConnectionString(connectionString)
-            .Name(_queueName)
+        return new AzureStorageQueue<SimpleWorkItem>(o =>
+        {
+            var builder = o
+                .ConnectionString(connectionString)
+                .Name(_queueName)
 #pragma warning disable CS0618 // Testing legacy mode intentionally
-            .CompatibilityMode(AzureStorageQueueCompatibilityMode.Legacy)
+                .CompatibilityMode(AzureStorageQueueCompatibilityMode.Legacy)
 #pragma warning restore CS0618
-            .Retries(retries)
-            .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
-            .DequeueInterval(TimeSpan.FromSeconds(1))
-            .MetricsPollingInterval(TimeSpan.Zero)
-            .TimeProvider(timeProvider)
-            .Serializer(serializer)
-            .LoggerFactory(Log));
+                .Retries(retries)
+                .WorkItemTimeout(workItemTimeout.GetValueOrDefault(TimeSpan.FromMinutes(5)))
+                .DequeueInterval(TimeSpan.FromSeconds(1))
+                .MetricsPollingInterval(TimeSpan.Zero)
+                .LoggerFactory(Log);
+
+            if (timeProvider is not null)
+                builder.TimeProvider(timeProvider);
+            if (serializer is not null)
+                builder.Serializer(serializer);
+
+            return builder;
+        });
     }
 
     protected override Task CleanupQueueAsync(IQueue<SimpleWorkItem> queue)

--- a/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Queues/LegacyAzureStorageQueueTests.cs
@@ -17,11 +17,11 @@ public class LegacyAzureStorageQueueTests : QueueTestBase
     {
     }
 
-    protected override IQueue<SimpleWorkItem> GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
+    protected override IQueue<SimpleWorkItem>? GetQueue(int retries = 1, TimeSpan? workItemTimeout = null, TimeSpan? retryDelay = null, int[]? retryMultipliers = null, int deadLetterMaxItems = 100, bool runQueueMaintenance = true, TimeProvider? timeProvider = null, ISerializer? serializer = null)
     {
         string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null!;
+            return null;
 
         _logger.LogDebug("Queue Id: {Name}", _queueName);
         return new AzureStorageQueue<SimpleWorkItem>(o =>

--- a/tests/Foundatio.AzureStorage.Tests/Storage/AzureStorageTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Storage/AzureStorageTests.cs
@@ -15,11 +15,11 @@ public class AzureStorageTests : FileStorageTestsBase
     {
     }
 
-    protected override IFileStorage GetStorage()
+    protected override IFileStorage? GetStorage()
     {
         string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null!;
+            return null;
 
         return new AzureFileStorage(o => o.ConnectionString(connectionString).LoggerFactory(Log));
     }

--- a/tests/Foundatio.AzureStorage.Tests/Storage/AzureStorageTests.cs
+++ b/tests/Foundatio.AzureStorage.Tests/Storage/AzureStorageTests.cs
@@ -17,9 +17,9 @@ public class AzureStorageTests : FileStorageTestsBase
 
     protected override IFileStorage GetStorage()
     {
-        string connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
+        string? connectionString = Configuration.GetConnectionString("AzureStorageConnectionString");
         if (String.IsNullOrEmpty(connectionString))
-            return null;
+            return null!;
 
         return new AzureFileStorage(o => o.ConnectionString(connectionString).LoggerFactory(Log));
     }


### PR DESCRIPTION
## Summary
- Replaced ineffective \<WarningsAsErrors>true</WarningsAsErrors>\ with correct \<TreatWarningsAsErrors>true</TreatWarningsAsErrors>\
- Fixed nullable reference warnings in queue implementation and tests

## Changes
- **build/common.props**: \WarningsAsErrors\ → \TreatWarningsAsErrors\
- **AzureStorageQueue.cs**: Null guard after envelope deserialization
- **Tests**: Assert.NotNull guards before Value dereference
- **Samples**: Conditional Properties assignment

## Test plan
- [x] \dotnet build Foundatio.All.slnx\ — 0 warnings, 0 errors